### PR TITLE
fix 'url' is not a valid tag on Django >=1.9

### DIFF
--- a/admin_resumable/templates/admin_resumable/file_input.html
+++ b/admin_resumable/templates/admin_resumable/file_input.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <script>
 (function($) {
     $(function() {


### PR DESCRIPTION
``RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.``