### PR TITLE
fnmatch string wasn't escaped. This broke on any files with "[" in the name

### DIFF
--- a/admin_resumable/files.py
+++ b/admin_resumable/files.py
@@ -3,7 +3,6 @@ import fnmatch
 
 from django.core.files.base import File
 
-
 class ResumableFile(object):
     def __init__(self, storage, kwargs):
         self.storage = storage
@@ -24,8 +23,7 @@ class ResumableFile(object):
         chunks = []
         files = sorted(self.storage.listdir('')[1])
         for file in files:
-            if fnmatch.fnmatch(file, '%s%s*' % (self.filename,
-                                                self.chunk_suffix)):
+            if file.startswith(self.filename+self.chunk_suffix):
                 chunks.append(file)
         return chunks
 
@@ -74,6 +72,7 @@ class ResumableFile(object):
     def is_complete(self):
         """Checks if all chunks are already stored.
         """
+        print("resumableTotalSize",int(self.kwargs.get('resumableTotalSize')),": size",self.size)
         return int(self.kwargs.get('resumableTotalSize')) == self.size
 
     def process_chunk(self, file):

--- a/admin_resumable/static/admin_resumable/js/resumable.js
+++ b/admin_resumable/static/admin_resumable/js/resumable.js
@@ -35,7 +35,7 @@
     var $ = this;
     $.files = [];
     $.defaults = {
-      chunkSize:1*1024*1024,
+      chunkSize:1000*900,
       forceChunkSize:false,
       simultaneousUploads:3,
       fileParameterName:'file',


### PR DESCRIPTION
And probably on a lot of other things. Replaced fnmatch with
string.startswith

Also, this code is *waaay* too inefficient to use on a real site.